### PR TITLE
Deno Canary Compat: Updates to fromTimer()

### DIFF
--- a/src/sources/from-timer.ts
+++ b/src/sources/from-timer.ts
@@ -29,6 +29,6 @@ export function fromTimer(ms: number): Observable<null> {
     }
     clearInterval(timer);
   });
-  timer = setInterval(() => next(), ms);
+  timer = setInterval(() => next(null), ms);
   return observable;
 }

--- a/src/sources/from-timer.ts
+++ b/src/sources/from-timer.ts
@@ -29,6 +29,6 @@ export function fromTimer(ms: number): Observable<null> {
     }
     clearInterval(timer);
   });
-  timer = setInterval(next, ms);
+  timer = setInterval(() => next(), ms);
   return observable;
 }

--- a/src/sources/from-timer.ts
+++ b/src/sources/from-timer.ts
@@ -21,9 +21,12 @@ import { external } from "./external.ts";
  * @returns New observable that emits null values.
  */
 export function fromTimer(ms: number): Observable<null> {
-  let timer: number | null = null;
+  let timer: number | { close: () => unknown } | null = null;
   const { next, observable } = external<null>(() => {
-    if (typeof timer !== 'number') return;
+    if (typeof timer !== 'number') {
+      timer?.close();
+      return;
+    }
     clearInterval(timer);
   });
   timer = setInterval(next, ms);


### PR DESCRIPTION
In Deno Canary, setInterval appears to return a handle now instead of a number.